### PR TITLE
XML validation fixes

### DIFF
--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -313,7 +313,7 @@
       <bibtex:volume>43</bibtex:volume>
       <bibtex:number>20</bibtex:number>
       <bibtex:pages>3714-3717</bibtex:pages>
-      <bibtex:doi>10.1021/jm000942e</bibtex:doi>
+      <bibtex:crossref>DOI:10.1021/jm000942e</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>
 
@@ -379,7 +379,7 @@
       <bibtex:volume>5</bibtex:volume>
       <bibtex:number>6</bibtex:number>
       <bibtex:pages>345</bibtex:pages>
-      <bibtex:doi>10.1145/367766.368168</bibtex:doi>
+      <bibtex:crossref>DOI:10.1145/367766.368168</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>
 
@@ -426,7 +426,7 @@
       <bibtex:year>2006</bibtex:year>
       <bibtex:volume>46</bibtex:volume>
       <bibtex:pages>991-998</bibtex:pages>
-      <bibtex:doi>10.1021/ci050400b</bibtex:doi>
+      <bibtex:crossref>DOI:10.1021/ci050400b</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>
 
@@ -539,7 +539,7 @@
       <bibtex:pages>1-14</bibtex:pages>
       <bibtex:number>1</bibtex:number>
       <bibtex:url>https://doi.org/10.1186/1758-2946-3-3</bibtex:url>
-      <bibtex:doi>10.1186/1758-2946-3-3</bibtex:doi>
+      <bibtex:crossref>DOI:10.1186/1758-2946-3-3</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>
 
@@ -672,7 +672,7 @@
   <bibtex:entry bibtex:id="kind2007">
       <bibtex:article>
           <bibtex:author>Kind, Tobias   and Fiehn, Oliver</bibtex:author>
-          <bibtex:doi>10.1186/1471-2105-8-105</bibtex:doi>
+          <bibtex:crossref>DOI:10.1186/1471-2105-8-105</bibtex:crossref>
           <bibtex:journal>BMC Bioinformatics</bibtex:journal>
           <bibtex:year>2007</bibtex:year>
           <bibtex:title>Seven Golden Rules for heuristic filtering of molecular formulas
@@ -858,7 +858,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       <bibtex:volume>43</bibtex:volume>
       <bibtex:number>3</bibtex:number>
       <bibtex:pages>757-772</bibtex:pages>
-      <bibtex:doi>10.1021/ci0256541</bibtex:doi>
+      <bibtex:crossref>DOI:10.1021/ci0256541</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>
 
@@ -879,7 +879,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       <bibtex:volume>44</bibtex:volume>
       <bibtex:number>2</bibtex:number>
       <bibtex:pages>462-469</bibtex:pages>
-      <bibtex:doi>10.1021/ci034244p</bibtex:doi>
+      <bibtex:crossref>DOI:10.1021/ci034244p</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>
 
@@ -931,7 +931,7 @@ obtained by accurate mass spectrometry</bibtex:title>
           heterogeneous network of almost any number and type of computers, thus allowing
           for parallel CASE computations on ordinary networks, present in almost any
           institution.[References: 23]</bibtex:abstract>
-      <bibtex:doi>10.1021/ci000407n</bibtex:doi>
+      <bibtex:crossref>DOI:10.1021/ci000407n</bibtex:crossref>
       <bibtex:keywords>Chemical-structure,Natural-products,Spectroscopy,Molecules,Search.,
           Chemistry in Current Contents(R)/Physical, Chemical and Earth,Sciences.</bibtex:keywords>
     </bibtex:article>
@@ -945,7 +945,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       <bibtex:year>2002</bibtex:year>
       <bibtex:volume>43</bibtex:volume>
       <bibtex:number>6</bibtex:number>
-      <bibtex:doi>10.1021/ci0341363</bibtex:doi>
+      <bibtex:crossref>DOI:10.1021/ci0341363</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>
 
@@ -957,7 +957,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       <bibtex:year>2003</bibtex:year>
       <bibtex:volume>43</bibtex:volume>
       <bibtex:pages>493-500</bibtex:pages>
-      <bibtex:doi>10.1021/ci025584y</bibtex:doi>
+      <bibtex:crossref>DOI:10.1021/ci025584y</bibtex:crossref>
       <bibtex:url>http://www.cdk.org/</bibtex:url>
     </bibtex:article>
   </bibtex:entry>
@@ -970,7 +970,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       <bibtex:year>2009</bibtex:year>
       <bibtex:volume>49</bibtex:volume>
       <bibtex:pages>338–347</bibtex:pages>
-      <bibtex:doi>10.1021/ci800326z</bibtex:doi>
+      <bibtex:crossref>DOI:10.1021/ci800326z</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>
 
@@ -993,7 +993,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       <bibtex:year>2006</bibtex:year>
       <bibtex:volume>46</bibtex:volume>
       <bibtex:pages>1912-1918</bibtex:pages>
-      <bibtex:doi>10.1021/ci6002152</bibtex:doi>
+      <bibtex:crossref>DOI:10.1021/ci6002152</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>
 
@@ -1285,7 +1285,7 @@ Method </bibtex:title>
           <bibtex:volume>7</bibtex:volume>
           <bibtex:number>8</bibtex:number>
           <bibtex:pages>1118-1126</bibtex:pages>
-          <bibtex:doi>10.1002/smll.201002366</bibtex:doi>
+          <bibtex:crossref>DOI:10.1002/smll.201002366</bibtex:crossref>
       </bibtex:article>
   </bibtex:entry>
 
@@ -1324,7 +1324,7 @@ Method </bibtex:title>
             <bibtex:year>1986</bibtex:year>
             <bibtex:volume>7</bibtex:volume>
             <bibtex:pages>565-577</bibtex:pages>
-            <bibtex:doi>10.1002/jcc.540070419</bibtex:doi>
+            <bibtex:crossref>DOI:10.1002/jcc.540070419</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>
 
@@ -1337,7 +1337,7 @@ Method </bibtex:title>
             <bibtex:year>1987</bibtex:year>
             <bibtex:volume>27</bibtex:volume>
             <bibtex:pages>21-35</bibtex:pages>
-            <bibtex:doi>10.1021/ci00053a005</bibtex:doi>
+            <bibtex:crossref>DOI:10.1021/ci00053a005</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>
 
@@ -1361,7 +1361,7 @@ Method </bibtex:title>
             <bibtex:year>1995</bibtex:year>
             <bibtex:volume>35</bibtex:volume>
             <bibtex:pages>1039-1045</bibtex:pages>
-            <bibtex:doi>10.1021/ci00028a014</bibtex:doi>
+            <bibtex:crossref>DOI:10.1021/ci00028a014</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>
 
@@ -1377,7 +1377,7 @@ Method </bibtex:title>
             <bibtex:year>2004</bibtex:year>
             <bibtex:volume>9</bibtex:volume>
             <bibtex:pages>1004-1009</bibtex:pages>
-            <bibtex:doi>10.3390/91201004</bibtex:doi>
+            <bibtex:crossref>DOI:10.3390/91201004</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>
 
@@ -1391,7 +1391,7 @@ Method </bibtex:title>
             <bibtex:year>2000</bibtex:year>
             <bibtex:volume>18</bibtex:volume>
             <bibtex:pages>464-477</bibtex:pages>
-            <bibtex:doi>10.1016/S1093-3263(00)00068-1</bibtex:doi>
+            <bibtex:crossref>DOI:10.1016/S1093-3263(00)00068-1</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry> 
 
@@ -1403,7 +1403,7 @@ Method </bibtex:title>
             <bibtex:year>2006</bibtex:year>
             <bibtex:volume>78</bibtex:volume>
             <bibtex:pages>1897-1970</bibtex:pages>
-            <bibtex:doi>10.1351/pac200678101897</bibtex:doi>
+            <bibtex:crossref>DOI:10.1351/pac200678101897</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>
 
@@ -1415,7 +1415,7 @@ Method </bibtex:title>
             <bibtex:year>2009</bibtex:year>
             <bibtex:volume>1</bibtex:volume>
             <bibtex:pages>12</bibtex:pages>
-            <bibtex:doi>10.1186/1758-2946-1-12</bibtex:doi>
+            <bibtex:crossref>DOI:10.1186/1758-2946-1-12</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>
 
@@ -1427,7 +1427,7 @@ Method </bibtex:title>
             <bibtex:year>2010</bibtex:year>
             <bibtex:volume>ASAP</bibtex:volume>
             <bibtex:pages></bibtex:pages>
-            <bibtex:doi>10.1021/jm1008456</bibtex:doi>
+            <bibtex:crossref>DOI:10.1021/jm1008456</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>
 
@@ -1439,7 +1439,7 @@ Method </bibtex:title>
             <bibtex:year>2005</bibtex:year>
             <bibtex:volume>45</bibtex:volume>
             <bibtex:pages>386-393</bibtex:pages>
-            <bibtex:doi>10.1021/ci0496797</bibtex:doi>
+            <bibtex:crossref>DOI:10.1021/ci0496797</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>
 
@@ -1474,7 +1474,7 @@ Method </bibtex:title>
       <bibtex:volume>68</bibtex:volume>
       <bibtex:number>19</bibtex:number>
       <bibtex:pages>7368-7373</bibtex:pages>
-      <bibtex:doi>10.1021/jo034808o</bibtex:doi>
+      <bibtex:crossref>DOI:10.1021/jo034808o</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>
    
@@ -1486,7 +1486,7 @@ Method </bibtex:title>
             <bibtex:year>2010</bibtex:year>
             <bibtex:volume>50</bibtex:volume>
             <bibtex:pages>1223-1232</bibtex:pages>
-            <bibtex:doi>10.1021/ci1001179</bibtex:doi>
+            <bibtex:crossref>DOI:10.1021/ci1001179</bibtex:crossref>
         </bibtex:article>
    </bibtex:entry>
    
@@ -1499,7 +1499,7 @@ Method </bibtex:title>
       <bibtex:volume></bibtex:volume>
       <bibtex:number></bibtex:number>
       <bibtex:pages></bibtex:pages>
-      <bibtex:doi>10.1093/bioinformatics/btr409</bibtex:doi>
+      <bibtex:crossref>DOI:10.1093/bioinformatics/btr409</bibtex:crossref>
     </bibtex:article>
     
   </bibtex:entry>
@@ -1512,7 +1512,7 @@ Method </bibtex:title>
       <bibtex:number>21</bibtex:number> 
       <bibtex:pages>2518-2525</bibtex:pages> 
       <bibtex:year>2008</bibtex:year> 
-      <bibtex:doi>10.1093/bioinformatics/btn479</bibtex:doi>
+      <bibtex:crossref>DOI:10.1093/bioinformatics/btn479</bibtex:crossref>
       <bibtex:URL>http://bioinformatics.oxfordjournals.org/content/24/21/2518.abstract</bibtex:URL> 
       <bibtex:eprint>http://bioinformatics.oxfordjournals.org/content/24/21/2518.full.pdf+html</bibtex:eprint> 
       <bibtex:journal>Bioinformatics</bibtex:journal>
@@ -1528,7 +1528,7 @@ Method </bibtex:title>
             <bibtex:journal>Journal of the Association for Computing Machinery</bibtex:journal>
             <bibtex:volume>23</bibtex:volume>
             <bibtex:number>1</bibtex:number>
-            <bibtex:doi>10.1145/321921.321925</bibtex:doi>
+            <bibtex:crossref>DOI:10.1145/321921.321925</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>  
     
@@ -1567,7 +1567,7 @@ Method </bibtex:title>
             <bibtex:journal>J. Chem. Inf. Comput. Sci</bibtex:journal>
             <bibtex:volume>33</bibtex:volume>
             <bibtex:pages>812-825</bibtex:pages>
-            <bibtex:doi>10.1021/ci00016a003</bibtex:doi>
+            <bibtex:crossref>DOI:10.1021/ci00016a003</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>
     
@@ -1579,7 +1579,7 @@ Method </bibtex:title>
              <bibtex:year>2010</bibtex:year>
              <bibtex:volume>50</bibtex:volume>
              <bibtex:pages>742-754</bibtex:pages>
-             <bibtex:doi>10.1021/ci100050t</bibtex:doi>
+             <bibtex:crossref>DOI:10.1021/ci100050t</bibtex:crossref>
          </bibtex:article>
     </bibtex:entry>
     
@@ -1591,7 +1591,7 @@ Method </bibtex:title>
             <bibtex:journal>Journal of Cheminformatics</bibtex:journal>
             <bibtex:volume>4</bibtex:volume>
             <bibtex:number>22</bibtex:number>
-            <bibtex:doi>10.1186/1758-2946-4-22</bibtex:doi>
+            <bibtex:crossref>DOI:10.1186/1758-2946-4-22</bibtex:crossref>
         </bibtex:article>
     </bibtex:entry>
     

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -39,7 +39,7 @@
     </bibtex:book>
   </bibtex:entry>
 
-  <bibtex:entry id="AiresDeSousa2002">
+  <bibtex:entry bibtex:id="AiresDeSousa2002">
     <bibtex:article>
       <bibtex:author>Aires-de-Sousa, J. and Hemmer, M.C. and Gasteiger, J.</bibtex:author>
       <bibtex:title>Prediction of 1H NMR Chemical Shifts Using Neural Networks</bibtex:title>
@@ -51,7 +51,7 @@
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="batchelor13">
+  <bibtex:entry bibtex:id="batchelor13">
     <bibtex:inproceedings>
       <bibtex:author>Colin Batchelor and Ken Karapetyan and Valery Tkachenko and Anthony Williams</bibtex:author>
       <bibtex:title>Validation and standardization of molecular structures in general and sugars in particular: a case study</bibtex:title>
@@ -61,7 +61,7 @@
     </bibtex:inproceedings>
   </bibtex:entry>
   
-  <bibtex:entry id="BER2001">
+  <bibtex:entry bibtex:id="BER2001">
     <bibtex:misc>
       <bibtex:author>Bernstein, H.J.</bibtex:author>
       <bibtex:title>Manual RasMol 2.7.2.1 - CPK Colours</bibtex:title>
@@ -69,7 +69,7 @@
     </bibtex:misc>
   </bibtex:entry>
 
-  <bibtex:entry id="BGdV04a">
+  <bibtex:entry bibtex:id="BGdV04a">
     <bibtex:article>
       <bibtex:author>Berger, F. and Gritzmann, P. and De Vries, S.</bibtex:author>
       <bibtex:title>Minimum cycle bases for network graphs</bibtex:title>
@@ -80,7 +80,7 @@
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="BODR10">
+  <bibtex:entry bibtex:id="BODR10">
     <bibtex:misc>
       <bibtex:author>Willighagen, E. and Hutchinson, G. and Niehaus, C. and Buchwald, J. and Pfeiffer, M. and Leidert, D. and Brefort, J.</bibtex:author>
       <bibtex:title>Blue Obelisk Data Repository (version 10)</bibtex:title>
@@ -90,7 +90,7 @@
     </bibtex:misc>
   </bibtex:entry>
 
-  <bibtex:entry id="Brecher08">
+  <bibtex:entry bibtex:id="Brecher08">
     <bibtex:article>
       <bibtex:author>Jonathan Brecher</bibtex:author>
       <bibtex:title>Graphical representation standards for chemical structure diagrams (IUPAC Recommendations 2008)</bibtex:title>
@@ -102,7 +102,7 @@
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="Cahn1966">
+  <bibtex:entry bibtex:id="Cahn1966">
     <bibtex:article>
       <bibtex:author>Cahn, R.S. and Ingold, C. and Prelog, V.</bibtex:author>
       <bibtex:title>Specification of Molecular Chirality</bibtex:title>
@@ -114,7 +114,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Cieplak2001">
+  <bibtex:entry bibtex:id="Cieplak2001">
     <bibtex:article>
       <bibtex:author>Cieplak, T and Wisniewski J. L.</bibtex:author>
       <bibtex:title>A New Effective Algorithm for the Unambiguous Identification of the Stereochemical Characteristics of Compounds During Their Registration in Databases</bibtex:title>
@@ -125,7 +125,7 @@
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="Clark06">
+  <bibtex:entry bibtex:id="Clark06">
     <bibtex:article>
       <bibtex:author>Clark AM, Labute P, Santavy M</bibtex:author>
       <bibtex:title>2D structure depiction</bibtex:title>
@@ -137,7 +137,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Clark13">
+  <bibtex:entry bibtex:id="Clark13">
     <bibtex:article>
       <bibtex:author>Clark A.</bibtex:author>
       <bibtex:title>Rendering Molecular Sketches for Publication Quality Output</bibtex:title>
@@ -148,7 +148,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Downs89">
+  <bibtex:entry bibtex:id="Downs89">
     <bibtex:article>
       <bibtex:author>Downs, G and Gillet, V and Holliday, J, and Lynch, M</bibtex:author>
       <bibtex:title>Theoretical Aspects of Ring Perception and Development of the Extended Set of Smallest Ring Concepts</bibtex:title>
@@ -160,7 +160,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Moreau1980">
+  <bibtex:entry bibtex:id="Moreau1980">
     <bibtex:article>
       <bibtex:author>Moreau G. and Broto P.</bibtex:author>
       <bibtex:title>The autocorrelation of a topological structure: A new molecular descriptor</bibtex:title>
@@ -171,7 +171,7 @@
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="BGdV04b">
+  <bibtex:entry bibtex:id="BGdV04b">
     <bibtex:techreport>
       <bibtex:author>Berger, F. and Gritzmann, P. and De Vries, S.</bibtex:author>
       <bibtex:title>Cyclic Invariants for Molecular Graphs</bibtex:title>
@@ -181,7 +181,7 @@
     </bibtex:techreport>
   </bibtex:entry>
 
-  <bibtex:entry id="Berger04">
+  <bibtex:entry bibtex:id="Berger04">
     <bibtex:article>
       <bibtex:author>Berger, F. and Flamm, C and Gleiss, P and Leydold, J and Stadler, P</bibtex:author>
       <bibtex:title>Counterexamples in Chemical Ring Perception</bibtex:title>
@@ -193,7 +193,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="BLE91">
+  <bibtex:entry bibtex:id="BLE91">
     <bibtex:article>
       <bibtex:author>Bley, K. and Brandt, J. and Dengler, A. and
         Frank, R. and Ugi, I.</bibtex:author>
@@ -205,7 +205,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="BRE78">
+  <bibtex:entry bibtex:id="BRE78">
     <bibtex:article>
       <bibtex:author>Bremser, W.</bibtex:author>
       <bibtex:title>HOSE - A Novel Substructure Code</bibtex:title>
@@ -216,7 +216,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="BRE85">
+  <bibtex:entry bibtex:id="BRE85">
     <bibtex:article>
       <bibtex:author>Bremser, W.</bibtex:author>
       <bibtex:title>Expectation Ranges of 13-C NMR Chemical Shifts</bibtex:title>
@@ -228,7 +228,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="BOR2002">
+  <bibtex:entry bibtex:id="BOR2002">
     <bibtex:inproceedings>
       <bibtex:author>Borgelt, C. and Berthold, M.R.</bibtex:author>
       <bibtex:title>Mining Molecular Fragments: Finding Relevant Substructures of Molecules</bibtex:title>
@@ -240,7 +240,7 @@
     </bibtex:inproceedings>
   </bibtex:entry>
 
-  <bibtex:entry id="BUR89">
+  <bibtex:entry bibtex:id="BUR89">
     <bibtex:article>
       <bibtex:author>Burden, F.R.</bibtex:author>
       <bibtex:title>Molecular identification number for substructure searches </bibtex:title>
@@ -252,7 +252,7 @@
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="BUR97">
+  <bibtex:entry bibtex:id="BUR97">
     <bibtex:article>
       <bibtex:author>Burden, F.R.</bibtex:author>
       <bibtex:title>Chemically Intuitive Molecular Index</bibtex:title>
@@ -263,7 +263,7 @@
     </bibtex:article>
   </bibtex:entry>
     
-  <bibtex:entry id="Cordella04">
+  <bibtex:entry bibtex:id="Cordella04">
     <bibtex:article>
       <bibtex:author>Cordella Luigi P and Foggia Pasquale and Carlo Sansone and Vento Mario </bibtex:author>
       <bibtex:title>A (Sub)Graph Isomorphism Algorithm for Matching Large Graphs</bibtex:title>
@@ -274,7 +274,7 @@
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="CHE03">
+  <bibtex:entry bibtex:id="CHE03">
     <bibtex:article>
       <bibtex:author>Cherkasov, A.</bibtex:author>
       <bibtex:title>Inductive Electronegativity Scale. Iterative Calculation of Inductive Partial Charges</bibtex:title>
@@ -285,7 +285,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="DAL92">
+  <bibtex:entry bibtex:id="DAL92">
     <bibtex:article>
       <bibtex:author>Dalby, A. and Nourse, J. G. and Hounshell, W. D. and
           Gushurst, A. K. and Grier, D. L. and Leland, B. A. and
@@ -302,7 +302,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="ERTL2000">
+  <bibtex:entry bibtex:id="ERTL2000">
     <bibtex:article>
       <bibtex:author>Ertl, P. and Rohde, B. and Selzer, P.</bibtex:author>
       <bibtex:title>Fast Calculation of Molecular Polar Surface Area as a Sum of 
@@ -317,7 +317,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="FAU96">
+  <bibtex:entry bibtex:id="FAU96">
     <bibtex:article>
       <bibtex:author>Faulon, J. L.</bibtex:author>
       <bibtex:title>Stochastic generator of chemical structure .2. Using simulated
@@ -331,7 +331,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="FAU03">
+  <bibtex:entry bibtex:id="FAU03">
     <bibtex:article>
       <bibtex:author>Faulon, J. L., Visco, D. P., and Pophale, R. S.</bibtex:author>
       <bibtex:title>The signature molecular descriptor. 1. Using extended
@@ -345,7 +345,7 @@
     </bibtex:article>
   </bibtex:entry>
   
-   <bibtex:entry id="FAU04">
+   <bibtex:entry bibtex:id="FAU04">
     <bibtex:article>
       <bibtex:author>Faulon, J. L., Collins, M. J., and Carr, R. D.</bibtex:author>
       <bibtex:title>The Signature Molecular Descriptor. 4. Canonizing Molecules
@@ -359,7 +359,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="FIG96">
+  <bibtex:entry bibtex:id="FIG96">
     <bibtex:article>
       <bibtex:author>Figueras, J.</bibtex:author>
       <bibtex:title>Ring Perception Using Breadth-First Search</bibtex:title>
@@ -370,7 +370,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="FLO62">
+  <bibtex:entry bibtex:id="FLO62">
     <bibtex:article>
       <bibtex:author>Floyd, R.W.</bibtex:author>
       <bibtex:title>Algorithm 97: Shortest path</bibtex:title>
@@ -383,7 +383,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="GH82">
+  <bibtex:entry bibtex:id="GH82">
     <bibtex:article>
       <bibtex:author>Gasteiger, J. and  Hutchings, M.G.</bibtex:author>
       <bibtex:title>Quantitative Models of Gas-Phase Proton Transfer Reactions Involving Alcohols, Ethers, and their Thio analogs. Correlation Analyses Based on Residual Electronegativity and Effective Polarizability</bibtex:title>
@@ -394,7 +394,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="GM2003">
+  <bibtex:entry bibtex:id="GM2003">
     <bibtex:inbook>
       <bibtex:author>Gasteiger, J.</bibtex:author>
       <bibtex:title>A Hierarchy of Structure Representations</bibtex:title>
@@ -407,7 +407,7 @@
     </bibtex:inbook>
   </bibtex:entry>
 
-  <bibtex:entry id="GM80">
+  <bibtex:entry bibtex:id="GM80">
     <bibtex:article>
       <bibtex:author>Gasteiger, J. and  Marsili, M.</bibtex:author>
       <bibtex:title> Iterative partial equalization of orbital elektronegativity - a rapid access to atomic charges</bibtex:title>
@@ -418,7 +418,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Guha2006">
+  <bibtex:entry bibtex:id="Guha2006">
     <bibtex:article>
       <bibtex:author>Guha, R. and Howard, M.T. and Hutchison, G.R. and Murray-Rust, P. and Rzepa, H. and Steinbeck, S. and Wegner, J. and Willighagen, E.L.</bibtex:author>
       <bibtex:title>The Blue Obelisks - Interoperability in Chemical Informatics</bibtex:title>
@@ -430,7 +430,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Saller85">
+  <bibtex:entry bibtex:id="Saller85">
     <bibtex:phdthesis>
       <bibtex:author>Saller, H.</bibtex:author>
       <bibtex:title>Quantitative Emperische Modelle fur Elektronische Effekte in Pi-Systemen und fur die Chemische Reaktivitat</bibtex:title>
@@ -440,7 +440,7 @@
     </bibtex:phdthesis>
   </bibtex:entry>
   
-  <bibtex:entry id="Halgren96a">
+  <bibtex:entry bibtex:id="Halgren96a">
       <bibtex:article>
         <bibtex:author>T. A. Halgren</bibtex:author>
         <bibtex:title>Merck Molecular Force Field. I. Basis, Form, Scope, Parametrization, and Performance of MMFF94</bibtex:title>
@@ -451,7 +451,7 @@
       </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="Halgren96b">
+  <bibtex:entry bibtex:id="Halgren96b">
         <bibtex:article>
           <bibtex:author>T. A. Halgren</bibtex:author>
           <bibtex:title>Merck Molecular Force Field. II. MMFF94 van der Waals and Electrostatic Parameters for Intermolecular Interactions</bibtex:title>
@@ -462,7 +462,7 @@
         </bibtex:article>
   </bibtex:entry>  
   
-  <bibtex:entry id="Halgren96c">
+  <bibtex:entry bibtex:id="Halgren96c">
         <bibtex:article>
           <bibtex:author>T. A. Halgren</bibtex:author>
           <bibtex:title>Merck Molecular Force Field. III. Molecular Geometries and Vibrational Frequencies for MMFF94</bibtex:title>
@@ -473,7 +473,7 @@
         </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="Halgren96d">
+  <bibtex:entry bibtex:id="Halgren96d">
         <bibtex:article>
           <bibtex:author>T. A. Halgren</bibtex:author>
           <bibtex:title>Merck Molecular Force Field. IV. Conformational Energies and Geometries for MMFF94</bibtex:title>
@@ -484,7 +484,7 @@
         </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="Halgren96e">
+  <bibtex:entry bibtex:id="Halgren96e">
         <bibtex:article>
           <bibtex:author>T. A. Halgren</bibtex:author>
           <bibtex:title>Merck Molecular Force Field. V. Extension of MMFF94 Using Experimental Data, Additional Computational Data, and Empirical Rules</bibtex:title>
@@ -495,7 +495,7 @@
         </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="HAN90">
+  <bibtex:entry bibtex:id="HAN90">
     <bibtex:article>
       <bibtex:author>Tonnelier, C. and Jauffret, Ph. and Hanser, Th. and Jauffret, Ph. and Kaufmann, G.</bibtex:author>
       <bibtex:title>Machine Learning of generic reactions: 3. An efficient algorithm for maximal common substructure determination</bibtex:title>
@@ -507,7 +507,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="HAN93">
+  <bibtex:entry bibtex:id="HAN93">
     <bibtex:phdthesis>
       <bibtex:author>Hanser, Th.</bibtex:author>
       <bibtex:title>Apprentissage automatique de m�thodes de synth�se � partir d'exemples</bibtex:title>
@@ -517,7 +517,7 @@
     </bibtex:phdthesis>
   </bibtex:entry>
 
-  <bibtex:entry id="HAN96">
+  <bibtex:entry bibtex:id="HAN96">
     <bibtex:article>
       <bibtex:author>Hanser, Th. and Jauffret, Ph. and Kaufmann, G.</bibtex:author>
       <bibtex:title>A New Algorithm for Exhaustive Ring Perception in a 
@@ -529,7 +529,7 @@
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="Hinselmann2011">
+  <bibtex:entry bibtex:id="Hinselmann2011">
     <bibtex:article>
       <bibtex:author>Hinselmann and Georg and Rosenbaum and Lars and Jahn and Andreas and Fechner and Nikolas and Zell and Andreas</bibtex:author>
       <bibtex:title>jCompoundMapper: An open source Java library and command line tool for chemical fingerprints</bibtex:title>
@@ -544,7 +544,7 @@
   </bibtex:entry>
 
 
-  <bibtex:entry id="HEL99">
+  <bibtex:entry bibtex:id="HEL99">
     <bibtex:inbook>
       <bibtex:author>Helson, Harold E.</bibtex:author>
       <bibtex:title>Structure Diagram Generation</bibtex:title>
@@ -558,7 +558,7 @@
     </bibtex:inbook>
   </bibtex:entry>
   
-  <bibtex:entry id="BGdV04a">
+  <bibtex:entry bibtex:id="BGdV04a">
     <bibtex:article>
       <bibtex:author>Berger, F. and Gritzmann, P. and De Vries, S.</bibtex:author>
       <bibtex:title>Minimum cycle bases for network graphs</bibtex:title>
@@ -569,7 +569,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="HEL01">
+  <bibtex:entry bibtex:id="HEL01">
     <bibtex:article>
       <bibtex:author>Stein, S. and Heller, S.</bibtex:author>
       <bibtex:title>IUPAC Chemical Identifier (IChI)</bibtex:title>
@@ -581,7 +581,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Hu94">
+  <bibtex:entry bibtex:id="Hu94">
     <bibtex:article>
       <bibtex:author>Hu, C.Y. and Xu, L.</bibtex:author>
       <bibtex:title>Algorithm for computer perception of topological symmetry</bibtex:title>
@@ -592,7 +592,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Hu94b">
+  <bibtex:entry bibtex:id="Hu94b">
     <bibtex:article>
       <bibtex:author>Hu, C.Y. and Xu, L.</bibtex:author>
       <bibtex:title>A New Scheme for Assignment of a Canonical Connection Table</bibtex:title>
@@ -603,7 +603,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="HU96">
+  <bibtex:entry bibtex:id="HU96">
     <bibtex:article>
       <bibtex:author>Chang-Yu Hu and Lu Xu</bibtex:author>
       <bibtex:title>On Highly Discriminating Molecular Topological Index</bibtex:title>
@@ -614,7 +614,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Hu99">
+  <bibtex:entry bibtex:id="Hu99">
     <bibtex:article>
        <bibtex:author>Hu, C.Y.</bibtex:author>
        <bibtex:title>Computer perception of topological symmetry by all-paths algorithm</bibtex:title>
@@ -625,7 +625,7 @@
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="Ihlenfeldt93">
+  <bibtex:entry bibtex:id="Ihlenfeldt93">
     <bibtex:article>
         <bibtex:author>Wolf Dietrich Ihlenfeldt and Johann Gasteiger</bibtex:author>
         <bibtex:title>Hash Codes for the Identification and Classification of Molecular Structure Elements</bibtex:title>
@@ -636,7 +636,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="KAB76">
+  <bibtex:entry bibtex:id="KAB76">
     <bibtex:article>
       <bibtex:author>Kabsch, W.</bibtex:author>
       <bibtex:title>A Solution for the Best Rotation to Relate Two Sets of Vectors</bibtex:title>
@@ -647,7 +647,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="KAB78">
+  <bibtex:entry bibtex:id="KAB78">
     <bibtex:article>
       <bibtex:author>Kabsch, W.</bibtex:author>
       <bibtex:title>Discussion of Solution for Best Rotation to Relate 2 Sets of Vectors</bibtex:title>
@@ -658,7 +658,7 @@
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="KAT96">
+  <bibtex:entry bibtex:id="KAT96">
       <bibtex:article>
           <bibtex:author>Katritzky, A.R. and Mu, L. and Lobanov, V.S. and Karelson, M.</bibtex:author>
           <bibtex:title>Correlation of Boiling Points With Molecular Structure. 1. A Training Set of 298 Diverse Organics and a Test Set of 9 Simple Inorganics</bibtex:title>
@@ -669,7 +669,7 @@
       </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="kind2007">
+  <bibtex:entry bibtex:id="kind2007">
       <bibtex:article>
           <bibtex:author>Kind, Tobias   and Fiehn, Oliver</bibtex:author>
           <bibtex:doi>10.1186/1471-2105-8-105</bibtex:doi>
@@ -682,7 +682,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="KJ81">
+  <bibtex:entry bibtex:id="KJ81">
     <bibtex:article>
       <bibtex:author>Kang, Y.K. and  Jhon, M.S.</bibtex:author>
       <bibtex:title>Additivity of Atomic Static Polarizabilities and Dispersion Coefficients</bibtex:title>
@@ -693,7 +693,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="KRA00">
+  <bibtex:entry bibtex:id="KRA00">
       <bibtex:article>
           <bibtex:author>Krause, Stefan and Willighagen, Egon and Steinbeck,
               Christoph</bibtex:author>
@@ -706,7 +706,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Kreher98">
+  <bibtex:entry bibtex:id="Kreher98">
       <bibtex:book>
           <bibtex:title>Combinatorial Algorithms Generation Enumeration and Search</bibtex:title>
           <bibtex:author>Kreher, Donald and Stinson, Douglas</bibtex:author>
@@ -715,7 +715,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       </bibtex:book>
   </bibtex:entry>
   
-  <bibtex:entry id="Pluskal2012">
+  <bibtex:entry bibtex:id="Pluskal2012">
     <bibtex:article>
       <bibtex:title>Highly accurate chemical formula prediction tool utilizing high-resolution mass spectra, MS/MS fragmentation, heuristic rules, and isotope pattern matching</bibtex:title>
       <bibtex:author>Pluskal, Tomas and Uehara, Taisuke and Yanagida, Mitsuhiro</bibtex:author>
@@ -728,7 +728,7 @@ obtained by accurate mass spectrometry</bibtex:title>
   </bibtex:entry>
 
 
-  <bibtex:entry id="MAR89">
+  <bibtex:entry bibtex:id="MAR89">
     <bibtex:article>
       <bibtex:author>Marston, C.C.</bibtex:author>
       <bibtex:title></bibtex:title>
@@ -739,7 +739,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Mannhold2009">
+  <bibtex:entry bibtex:id="Mannhold2009">
     <bibtex:article>
       <bibtex:author>Mannhold, R. and Poda, G.I. and Ostermann, C. and Tetko, I.V.</bibtex:author>
       <bibtex:title>Calculation of molecular lipophilicity: State-of-the-art and comparison of log P methods on more than 96,000 compounds</bibtex:title>
@@ -750,7 +750,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Molchanova96">
+  <bibtex:entry bibtex:id="Molchanova96">
     <bibtex:article>
       <bibtex:author>Molchanova</bibtex:author>
       <bibtex:title>Computer Generation of Molecular Structures by the SMOG Program</bibtex:title>
@@ -761,7 +761,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Molodtsov94">
+  <bibtex:entry bibtex:id="Molodtsov94">
     <bibtex:article>
       <bibtex:author>Molodtsov, S.G.</bibtex:author>
       <bibtex:title>Computer-Aided Generation of Molecular Graphs</bibtex:title>
@@ -772,7 +772,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="MOR65">
+  <bibtex:entry bibtex:id="MOR65">
     <bibtex:article>
       <bibtex:author>Morgan, H.L.</bibtex:author>
       <bibtex:title>The Generation of a Unique Machine Description for Chemical
@@ -784,7 +784,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Nilakantan06">
+  <bibtex:entry bibtex:id="Nilakantan06">
     <bibtex:article>
       <bibtex:author>Nilakantan, R. and Nunn, D.S. and Greenblatt, L. and Walker, G. and Haraki, K. and Mobilio, D.</bibtex:author>
       <bibtex:title>A family of ring system-based structural fragments for use in structure-activity studies: database mining and recursive partitioning.</bibtex:title>
@@ -796,7 +796,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="OS">
+  <bibtex:entry bibtex:id="OS">
     <bibtex:book>
       <bibtex:editor>Csaszar, F.</bibtex:editor>
       <bibtex:title>The Open Source Reader</bibtex:title>
@@ -811,7 +811,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:book>
   </bibtex:entry>
   
-  <bibtex:entry id="PEA99">
+  <bibtex:entry bibtex:id="PEA99">
     <bibtex:article>
       <bibtex:author>Pearlman, R.S. and Smith, K.M.</bibtex:author>
       <bibtex:title> Metric Validation and the Receptor-Relevant Subspace Concept</bibtex:title>
@@ -823,7 +823,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="PMR99">
+  <bibtex:entry bibtex:id="PMR99">
     <bibtex:article>
       <bibtex:author>Murray-Rust, P. and Rzepa, H.S.</bibtex:author>
       <bibtex:title>Chemical markup, XML, and the Worldwide Web. 1. Basic
@@ -848,7 +848,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="PMR2003">
+  <bibtex:entry bibtex:id="PMR2003">
     <bibtex:article>
       <bibtex:author>Murray-Rust, P. and Rzepa, H.S.</bibtex:author>
       <bibtex:title>Chemical Markup, XML, and the World Wide Web. 4. CML Schema</bibtex:title>
@@ -862,7 +862,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="PMR2002">
+  <bibtex:entry bibtex:id="PMR2002">
     <bibtex:misc>
       <bibtex:author>Murray-Rust, P. and Rzepa, H.S.</bibtex:author>
       <bibtex:title>STMML. A MARKUP LANGUAGE FOR SCIENTIFIC, TECHNICAL AND MEDICAL PUBLISHING</bibtex:title>
@@ -870,7 +870,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:misc>
   </bibtex:entry>
 
-  <bibtex:entry id="RZEPA04">
+  <bibtex:entry bibtex:id="RZEPA04">
     <bibtex:article>
       <bibtex:author>Murray-Rust, P. and Rzepa, H.S. and Williamson, M.J. and Willighagen, E.L.</bibtex:author>
       <bibtex:title>Chemical Markup, XML, and the World Wide Web. 5. Applications of Chemical Metadata in RSS Aggregators</bibtex:title>
@@ -883,21 +883,21 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="SMILESTUT">
+  <bibtex:entry bibtex:id="SMILESTUT">
     <bibtex:misc>
       <bibtex:title>SMILES Tutorial</bibtex:title>
       <bibtex:url>http://www.daylight.com/dayhtml/smiles/smiles-intro.html</bibtex:url>
     </bibtex:misc>
   </bibtex:entry>
 
-  <bibtex:entry id="SSMILESTUT">
+  <bibtex:entry bibtex:id="SSMILESTUT">
     <bibtex:misc>
       <bibtex:title>SSMILES Tutorial</bibtex:title>
       <bibtex:url>http://www.daylight.com/dayhtml/smiles/ssmiles.html</bibtex:url>
     </bibtex:misc>
   </bibtex:entry>
   
-  <bibtex:entry id="SCH84">
+  <bibtex:entry bibtex:id="SCH84">
     <bibtex:article>
       <bibtex:author>Von Scholley, A.</bibtex:author>
       <bibtex:title></bibtex:title>
@@ -908,7 +908,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="STE2001">
+  <bibtex:entry bibtex:id="STE2001">
     <bibtex:article>
       <bibtex:author>Steinbeck, C.</bibtex:author>
       <bibtex:title>SENECA: A platform-independent, distributed, and parallel system
@@ -937,7 +937,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="STE2002">
+  <bibtex:entry bibtex:id="STE2002">
     <bibtex:article>
       <bibtex:author>Steinbeck, C. and Kuhn, S. and Krause, S.</bibtex:author>
       <bibtex:title>NMRShiftDB - Constructing a Chemical Information System with Open Source Components</bibtex:title>
@@ -949,7 +949,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="STE2003">
+  <bibtex:entry bibtex:id="STE2003">
     <bibtex:article>
       <bibtex:author>Steinbeck, C. and Han, Y. and Kuhn, S, and Horlacher, O. and Luttmann, E. and Willighagen, E.</bibtex:author>
       <bibtex:title>The Chemistry Development Kit (CDK): An Open-Source Java Library for Chemo- and Bioinformatics</bibtex:title>
@@ -962,7 +962,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="Steffen09">
+  <bibtex:entry bibtex:id="Steffen09">
     <bibtex:article>
       <bibtex:author>Andreas Steffen, Thierry Kogej, Christian Tyrchan and Ola Engkvist</bibtex:author>
       <bibtex:title>Comparison of Molecular Fingerprint Methods on the Basis of Biological Profile Data</bibtex:title>
@@ -974,7 +974,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Shelley83">
+  <bibtex:entry bibtex:id="Shelley83">
     <bibtex:article>
       <bibtex:author>Shelley CA</bibtex:author>
       <bibtex:title>Heuristic Approach for Displaying Chemical Structures</bibtex:title>
@@ -985,7 +985,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="Grant06">
+  <bibtex:entry bibtex:id="Grant06">
     <bibtex:article>
       <bibtex:author>J.A. Grant, J.A. Haigh, B.T. Pickup, A. Nicholls and R.A. Sayle</bibtex:author>
       <bibtex:title>Lingos, Finite State Machines, and Fast Similarity Searching</bibtex:title>
@@ -997,7 +997,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="TOD98">
+  <bibtex:entry bibtex:id="TOD98">
     <bibtex:article>
       <bibtex:author>Todeschini, R. and Gramatica, P.</bibtex:author>
       <bibtex:title>New 3D Molecular Descriptors: The WHIM theory and QAR Applications</bibtex:title>
@@ -1007,7 +1007,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="TOD2000">
+  <bibtex:entry bibtex:id="TOD2000">
     <bibtex:inbook>
       <bibtex:author>Todeschini, R. and Consonni, V.</bibtex:author>
       <bibtex:title></bibtex:title>
@@ -1021,7 +1021,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:inbook>
   </bibtex:entry>
 
-  <bibtex:entry id="TRI92">
+  <bibtex:entry bibtex:id="TRI92">
     <bibtex:book>
       <bibtex:author>Trinijastic, N.</bibtex:author>
       <bibtex:title>Chemical Graph Theory</bibtex:title>
@@ -1031,7 +1031,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:book>
   </bibtex:entry>
 
-  <bibtex:entry id="WANG00">
+  <bibtex:entry bibtex:id="WANG00">
     <bibtex:article>
         <bibtex:author>Wang, R., Gao, Y., and Lai, L.</bibtex:author>
         <bibtex:title>Calculating partition coefficient by atom-additive method</bibtex:title>
@@ -1042,7 +1042,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="WANG97">
+  <bibtex:entry bibtex:id="WANG97">
     <bibtex:article>
         <bibtex:author>Wang, R., Fu, Y., and Lai, L.</bibtex:author>
         <bibtex:title>A New Atom-Additive Method for Calculating Partition Coefficients</bibtex:title>
@@ -1054,7 +1054,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="WEI88">
+  <bibtex:entry bibtex:id="WEI88">
     <bibtex:article>
       <bibtex:author>Weininger, David</bibtex:author>
       <bibtex:title>SMILES, a Chemical Language and Information System. 1.
@@ -1068,7 +1068,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="WEI89">
+  <bibtex:entry bibtex:id="WEI89">
     <bibtex:article>
       <bibtex:author>Weininger, David and Weininger, Arthur and Weininger, Joseph
         L.</bibtex:author>
@@ -1083,7 +1083,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="Wiener1947">
+  <bibtex:entry bibtex:id="Wiener1947">
     <bibtex:article>
       <bibtex:author>Wiener, Harry</bibtex:author>
       <bibtex:title>Structural Determination of Paraffin Boiling Points</bibtex:title>
@@ -1094,7 +1094,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-   <bibtex:entry id="SHA97">
+   <bibtex:entry bibtex:id="SHA97">
     <bibtex:article>
         <bibtex:author>
             Sharma, V. and Goswami, R. and Madan, A.K.
@@ -1112,7 +1112,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
  
-  <bibtex:entry id="WES98">
+  <bibtex:entry bibtex:id="WES98">
     <bibtex:article>
         <bibtex:author>Wessel, M.D. and Jurs, P.C. and Tolan, J.W. and Muskal, S.M.
         </bibtex:author>
@@ -1126,7 +1126,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="STA90">
+  <bibtex:entry bibtex:id="STA90">
     <bibtex:article>
         <bibtex:author>Stanton, D.T. and Jurs, P.C.
         </bibtex:author>
@@ -1138,7 +1138,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
   
-  <bibtex:entry id="MH1997">
+  <bibtex:entry bibtex:id="MH1997">
     <bibtex:article>
         <bibtex:author>Hendlich, M. and Rippmann, F. and Bernickel, G.
         </bibtex:author>
@@ -1151,7 +1151,7 @@ obtained by accurate mass spectrometry</bibtex:title>
   </bibtex:entry>
 
 
-  <bibtex:entry id="EIS95">
+  <bibtex:entry bibtex:id="EIS95">
     <bibtex:article>
         <bibtex:author>Eisenhaber, F. and Lijnzaad, P. and Argos, P. and Sander, C. and Scharf, M.
         </bibtex:author>
@@ -1164,7 +1164,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="WIL01">
+  <bibtex:entry bibtex:id="WIL01">
     <bibtex:article>
       <bibtex:author>Willighagen, E.L.</bibtex:author>
       <bibtex:title>Processing CML Conventions in Java</bibtex:title>
@@ -1184,7 +1184,7 @@ obtained by accurate mass spectrometry</bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="XML">
+  <bibtex:entry bibtex:id="XML">
       <bibtex:misc>
           <bibtex:author>World Wide Web Consortium</bibtex:author>
           <bibtex:title>Extensible Markup Language (XML) 1.0</bibtex:title>
@@ -1194,7 +1194,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       </bibtex:misc>
   </bibtex:entry>
 
-  <bibtex:entry id="PET92">
+  <bibtex:entry bibtex:id="PET92">
       <bibtex:article>
           <bibtex:author>  Petitjean, M.
           </bibtex:author>
@@ -1205,7 +1205,7 @@ obtained by accurate mass spectrometry</bibtex:title>
           <bibtex:pages>331-337</bibtex:pages>
       </bibtex:article>
   </bibtex:entry>
-  <bibtex:entry id="BAT95">
+  <bibtex:entry bibtex:id="BAT95">
       <bibtex:article>
           <bibtex:author> Bath, P.A. and Poirette, A.R. and Willet, P. and Allen, F.H.
           </bibtex:author>
@@ -1216,7 +1216,7 @@ obtained by accurate mass spectrometry</bibtex:title>
           <bibtex:pages>714-716</bibtex:pages>
       </bibtex:article>
   </bibtex:entry>
-  <bibtex:entry id="RAN84">
+  <bibtex:entry bibtex:id="RAN84">
       <bibtex:article>
           <bibtex:author>Randic, M.
           </bibtex:author>
@@ -1227,7 +1227,7 @@ obtained by accurate mass spectrometry</bibtex:title>
           <bibtex:pages>164-175</bibtex:pages>
       </bibtex:article>
   </bibtex:entry>
-  <bibtex:entry id="MURCKO96">
+  <bibtex:entry bibtex:id="MURCKO96">
       <bibtex:article>
           <bibtex:author>Bemis, G.W. and Murcko, M.A.
           </bibtex:author>
@@ -1239,7 +1239,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="BREN1995">
+  <bibtex:entry bibtex:id="BREN1995">
       <bibtex:article>
           <bibtex:author>Breneman, C.M. and Thompson, T.R. and Rhem, M. and Dung, M.
           </bibtex:author>
@@ -1250,7 +1250,7 @@ obtained by accurate mass spectrometry</bibtex:title>
           <bibtex:pages>161</bibtex:pages>
       </bibtex:article>
   </bibtex:entry>
-  <bibtex:entry id="BREN1997">
+  <bibtex:entry bibtex:id="BREN1997">
       <bibtex:article>
           <bibtex:author>Breneman, C.M. and Rhem, M.
           </bibtex:author>
@@ -1264,7 +1264,7 @@ Method </bibtex:title>
           <bibtex:pages>182-197</bibtex:pages>
       </bibtex:article>
   </bibtex:entry>
-  <bibtex:entry id="WHITE2003">
+  <bibtex:entry bibtex:id="WHITE2003">
       <bibtex:article>
           <bibtex:author>Whitehead, C.E. and Sukumar, N. and Breneman, C.M. and Ryan, M.D.
           </bibtex:author>
@@ -1276,7 +1276,7 @@ Method </bibtex:title>
       </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="Liu2011">
+  <bibtex:entry bibtex:id="Liu2011">
       <bibtex:article>
           <bibtex:author>Liu, R. and Rallo, R. and George, S. and Ji, Z. and Nair, S. and Nel, A.E. and Cohen, Y.</bibtex:author>
           <bibtex:title>Classification NanoSAR development for cytotoxicity of metal oxide nanoparticles</bibtex:title>
@@ -1289,7 +1289,7 @@ Method </bibtex:title>
       </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="LIU98">
+  <bibtex:entry bibtex:id="LIU98">
       <bibtex:article>
           <bibtex:author>Liu, S. and Cao, C. and Li, Z.
           </bibtex:author>
@@ -1303,7 +1303,7 @@ Method </bibtex:title>
       </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry id="BALL2007">
+  <bibtex:entry bibtex:id="BALL2007">
       <bibtex:article>
           <bibtex:author>Bellester, P.J. and Richards, W.G.
           </bibtex:author>
@@ -1315,7 +1315,7 @@ Method </bibtex:title>
       </bibtex:article>
   </bibtex:entry>
 
-    <bibtex:entry id="GHOSE1986">
+    <bibtex:entry bibtex:id="GHOSE1986">
         <bibtex:article>
             <bibtex:author>Ghose, A.K. and Crippen, G.M.
             </bibtex:author>
@@ -1328,7 +1328,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
 
-    <bibtex:entry id="GHOSE1987">
+    <bibtex:entry bibtex:id="GHOSE1987">
         <bibtex:article>
             <bibtex:author>Ghose, A.K. and Crippen, G.M.
             </bibtex:author>
@@ -1341,7 +1341,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
 
-	<bibtex:entry id="SallerH1995">
+	<bibtex:entry bibtex:id="SallerH1995">
     <bibtex:inbook>
       <bibtex:author>Saller, H.</bibtex:author>
       <bibtex:title></bibtex:title>
@@ -1352,7 +1352,7 @@ Method </bibtex:title>
     </bibtex:inbook>
   </bibtex:entry>
 
-    <bibtex:entry id="HALL1995">
+    <bibtex:entry bibtex:id="HALL1995">
         <bibtex:article>
             <bibtex:author>Hall, L.H. and Kier, L.B.
             </bibtex:author>
@@ -1365,7 +1365,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
 
-    <bibtex:entry id="BUTINA2004">
+    <bibtex:entry bibtex:id="BUTINA2004">
         <bibtex:article>
             <bibtex:author>Butina, D.
             </bibtex:author>
@@ -1381,7 +1381,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
 
-    <bibtex:entry id="LABUTE2000">
+    <bibtex:entry bibtex:id="LABUTE2000">
         <bibtex:article>
             <bibtex:author>Labute, P.
             </bibtex:author>
@@ -1395,7 +1395,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry> 
 
-    <bibtex:entry id="IUPAC2006">
+    <bibtex:entry bibtex:id="IUPAC2006">
         <bibtex:article>
             <bibtex:author>Brecher, Jonathan</bibtex:author>
             <bibtex:title>Graphical Representation of Stereochemical Configuration</bibtex:title>
@@ -1407,7 +1407,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
 
-    <bibtex:entry id="SMSD2009">
+    <bibtex:entry bibtex:id="SMSD2009">
         <bibtex:article>
             <bibtex:author>Rahman, S.A. and Bashton, M. and Holliday, G.L. and Schrader, R. and Thornton, J.M. </bibtex:author>
             <bibtex:title>Small Molecule Subgraph Detector (SMSD) Toolkit</bibtex:title>
@@ -1419,7 +1419,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
 
-   <bibtex:entry id="YANG2010">
+   <bibtex:entry bibtex:id="YANG2010">
         <bibtex:article>
             <bibtex:author>Yang, Y. and Chen, H. and Nilsson, I. and Muresan, S. and Engkvist, O.</bibtex:author>
             <bibtex:title>Investigation of the Relationship between Topology and Selectivity for Druglike Molecules</bibtex:title>
@@ -1431,7 +1431,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
 
-   <bibtex:entry id="Vidal2005">
+   <bibtex:entry bibtex:id="Vidal2005">
         <bibtex:article>
             <bibtex:author>Vidal, D. and Thormann, M. and Pons, M.</bibtex:author>
             <bibtex:title>LINGO, an Efficient Holographic Text Based Method To Calculate Biophysical Properties and Intermolecular Similarities</bibtex:title>
@@ -1443,7 +1443,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
 
-    <bibtex:entry id="WEGNER2006">
+    <bibtex:entry bibtex:id="WEGNER2006">
         <bibtex:thesis>
             <bibtex:author>Wegner, J. K.</bibtex:author>
             <bibtex:title>Data Mining und Graph Mining auf molekularen Graphen - Cheminformatik und molekulare Kodierungen f\"{u}r ADME/Tox QSAR Analysen</bibtex:title>
@@ -1453,7 +1453,7 @@ Method </bibtex:title>
         </bibtex:thesis>
     </bibtex:entry>
 
-  <bibtex:entry id="WILLIGHAGEN2004">
+  <bibtex:entry bibtex:id="WILLIGHAGEN2004">
     <bibtex:article>
       <bibtex:author>Willighagen, E.L.</bibtex:author>
       <bibtex:title>Customizing file IO</bibtex:title>
@@ -1465,7 +1465,7 @@ Method </bibtex:title>
     </bibtex:article>
   </bibtex:entry>
    
-  <bibtex:entry id="Zhao2003">
+  <bibtex:entry bibtex:id="Zhao2003">
     <bibtex:article>
       <bibtex:author>Zhao, Yuan H. and Abraham, Michael H. and Zissimos, Andreas M.</bibtex:author>
       <bibtex:title>Fast Calculation of van der Waals Volume as a Sum of Atomic and Bond Contributions and Its Application to Drug Compounds</bibtex:title>
@@ -1478,7 +1478,7 @@ Method </bibtex:title>
     </bibtex:article>
   </bibtex:entry>
    
-  <bibtex:entry id="Thalheim2010">
+  <bibtex:entry bibtex:id="Thalheim2010">
         <bibtex:article>
             <bibtex:author>Thalheim, T. and Vollmer, A. and Ebert, R. and Kuehne, R. and Schuurmann, G.</bibtex:author>
             <bibtex:title>Tautomer Identification and Tautomer Structure Generation Based on the InChI Code</bibtex:title>
@@ -1490,7 +1490,7 @@ Method </bibtex:title>
         </bibtex:article>
    </bibtex:entry>
    
-  <bibtex:entry id="RojasCherto2011">
+  <bibtex:entry bibtex:id="RojasCherto2011">
     <bibtex:article>	
       <bibtex:author>Rojas-Cherto, Miguel and Kasper, Piotr T and Willighagen, Egon L and Vreeken, R. and Hankemeier, Thomas and Reijmers, Theo</bibtex:author>
       <bibtex:title>Elemental Composition determination based on MSn</bibtex:title>
@@ -1504,7 +1504,7 @@ Method </bibtex:title>
     
   </bibtex:entry>
 
-  <bibtex:entry id="Klekota01112008">
+  <bibtex:entry bibtex:id="Klekota01112008">
   	<bibtex:article>
       <bibtex:author>Klekota, Justin and Roth, Frederick P.</bibtex:author>
       <bibtex:title>Chemical substructures that enrich for biological activity</bibtex:title>
@@ -1519,7 +1519,7 @@ Method </bibtex:title>
   	</bibtex:article>
   </bibtex:entry>
 
-    <bibtex:entry id="Ullmann76">
+    <bibtex:entry bibtex:id="Ullmann76">
         <bibtex:article>
             <bibtex:author>Ullmann J R</bibtex:author>
             <bibtex:title>An Algorithm for Subgraph Isomorphism</bibtex:title>
@@ -1532,7 +1532,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>  
     
-  <bibtex:entry id="Vismara97">
+  <bibtex:entry bibtex:id="Vismara97">
     <bibtex:article>
       <bibtex:author>Vismara, Philippe</bibtex:author>
       <bibtex:title>Union of all the minimum cycle bases of a graph</bibtex:title>
@@ -1544,7 +1544,7 @@ Method </bibtex:title>
     </bibtex:article>
   </bibtex:entry>
 
-    <bibtex:entry id="InChITechManual">
+    <bibtex:entry bibtex:id="InChITechManual">
         <bibtex:manual>
             <bibtex:title>IUPAC International Chemical Identifier (InChI), InChI
                 version 1, software version 1.04 (2011), Technical Manual
@@ -1559,7 +1559,7 @@ Method </bibtex:title>
         </bibtex:manual>
     </bibtex:entry>
 
-    <bibtex:entry id="Razinger93">
+    <bibtex:entry bibtex:id="Razinger93">
         <bibtex:article>
             <bibtex:title>Stereoisomer Generation in Computer-Enhanced Structure Elucidation</bibtex:title>
             <bibtex:author>Razinger, Marko and Balasubramaniam, Krishnan and Perdih, Marko and Munk, Morton</bibtex:author>
@@ -1571,7 +1571,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
     
-    <bibtex:entry id="Rogers2010">
+    <bibtex:entry bibtex:id="Rogers2010">
         <bibtex:article>
              <bibtex:author>Rogers and Hahn</bibtex:author>
              <bibtex:title>Extended-connectivity fingerprints</bibtex:title>
@@ -1583,7 +1583,7 @@ Method </bibtex:title>
          </bibtex:article>
     </bibtex:entry>
     
-    <bibtex:entry id="OBoyle12">
+    <bibtex:entry bibtex:id="OBoyle12">
         <bibtex:article>
             <bibtex:title>Towards a Universal SMILES representation - A standard method to generate canonical SMILES based on the InChI</bibtex:title>
             <bibtex:author>O'Boyle, Noel</bibtex:author>
@@ -1595,7 +1595,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
     
-    <bibtex:entry id="Edmonds65">
+    <bibtex:entry bibtex:id="Edmonds65">
         <bibtex:article>
             <bibtex:title>Paths, trees and flowers</bibtex:title>
             <bibtex:author>Edmonds, Jack</bibtex:author>
@@ -1606,7 +1606,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
     
-     <bibtex:entry id="Pluskal2012">
+     <bibtex:entry bibtex:id="Pluskal2012">
         <bibtex:article>
             <bibtex:title>Highly accurate chemical formula prediction tool utilizing high-resolution mass spectra, MS/MS fragmentation, heuristic rules, and isotope pattern matching</bibtex:title>
             <bibtex:author>Pluskal, Tomas and Uehara, Taisuke and Yanagida, Mitsuhiro</bibtex:author>
@@ -1618,7 +1618,7 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
 
-    <bibtex:entry id="Boecker2008">
+    <bibtex:entry bibtex:id="Boecker2008">
         <bibtex:article>
             <bibtex:title>DECOMP--from interpreting Mass Spectrometry peaks to solving the Money Changing Problem.</bibtex:title>
             <bibtex:author>Böcker, Sebastian and Lipták, Zsuzsanna and Martin, Marcel and Pervukhin, Anton and Sudek, Henner</bibtex:author>
@@ -1630,7 +1630,7 @@ Method </bibtex:title>
             <bibtex:url>http://bioinformatics.oxfordjournals.org/cgi/reprint/24/4/591?ijkey=1lM50Bkzz4SCLsa</bibtex:url>
         </bibtex:article>
     </bibtex:entry>
-    <bibtex:entry id="Duehrkop2013">
+    <bibtex:entry bibtex:id="Duehrkop2013">
         <bibtex:inproceedings>
             <bibtex:author>Dührkop, Kai and Ludwig, Marcus and Meusel, Marvin and Böcker, Sebastian</bibtex:author>
             <bibtex:title>Faster mass decomposition</bibtex:title>

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -1520,12 +1520,46 @@ Method </bibtex:title>
       <bibtex:volume>24</bibtex:volume>
       <bibtex:number>21</bibtex:number>
       <bibtex:pages>2518-2525</bibtex:pages>
-      <!-- FIXME:
-           <bibtex:eprint>http://bioinformatics.oxfordjournals.org/content/24/21/2518.full.pdf+html</bibtex:eprint>
-           – 'eprint' is not listed as an allowed element in the
-           schema :( -->
       <bibtex:crossref>DOI:10.1093/bioinformatics/btn479</bibtex:crossref>
-      <bibtex:url>http://bioinformatics.oxfordjournals.org/content/24/21/2518.abstract</bibtex:url> 
+      <bibtex:abstract>
+        From: http://bioinformatics.oxfordjournals.org/content/24/21/2518.abstract
+
+        License: Creative Commons Attribution Non-Commercial
+        License (http://creativecommons.org/licenses/by-nc/2.0/uk/)
+
+        Motivation: Certain chemical substructures are present
+        in many drugs. This has led to the claim of ‘privileged’
+        substructures which are predisposed to
+        bioactivity. Because bias in screening library
+        construction could explain this phenomenon, the
+        existence of privilege has been controversial.
+
+        Results: Using diverse phenotypic assays, we defined
+        bioactivity for multiple compound libraries. Many
+        substructures were associated with bioactivity even
+        after accounting for substructure prevalence in the
+        library, thus validating the privileged substructure
+        concept. Determinations of privilege were confirmed in
+        independent assays and libraries. Our analysis also
+        revealed ‘underprivileged’ substructures and
+        ‘conditional privilege’—rules relating combinations of
+        substructure to bioactivity. Most previously reported
+        substructures have been flat aromatic ring
+        systems. Although we validated such substructures, we
+        also identified three-dimensional privileged
+        substructures. Most privileged substructures display a
+        wide variety of substituents suggesting an entropic
+        mechanism of privilege. Compounds containing privileged
+        substructures had a doubled rate of bioactivity,
+        suggesting practical consequences for pharmaceutical
+        discovery.
+
+        Contact:fritz_roth@hms.harvard.edu
+
+        Supplementary information:Supplementary data are
+        available at Bioinformatics online.
+      </bibtex:abstract>
+      <bibtex:url>http://bioinformatics.oxfordjournals.org/content/24/21/2518.full.pdf+html</bibtex:url>
     </bibtex:article>
   </bibtex:entry>
 

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -55,8 +55,8 @@
     <bibtex:inproceedings>
       <bibtex:author>Colin Batchelor and Ken Karapetyan and Valery Tkachenko and Anthony Williams</bibtex:author>
       <bibtex:title>Validation and standardization of molecular structures in general and sugars in particular: a case study</bibtex:title>
-      <bibtex:year>2013</bibtex:year>
       <bibtex:booktitle>6th Joint Sheffield Conference on Chemoinformatics</bibtex:booktitle>
+      <bibtex:year>2013</bibtex:year>
       <bibtex:url>http://www.slideshare.net/RSC-Chemistry/20130724-cisrg-sugarsbatchelor</bibtex:url>
     </bibtex:inproceedings>
   </bibtex:entry>

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -5,6 +5,40 @@
 
   <!-- This file is preferably edited in jEdit with the XML plugin installed -->
 
+  <bibtex:entry bibtex:id="Murray1996">
+    <bibtex:book>
+      <bibtex:author>James F. Murray and William vanRyper</bibtex:author>
+      <bibtex:title>Encyclopedia of Graphics File Formats, 2nd ed.</bibtex:title>
+      <bibtex:publisher>O'Reilly &amp; Associates, Inc.</bibtex:publisher>
+      <bibtex:year>1996</bibtex:year>
+      <bibtex:month>May</bibtex:month>
+      <bibtex:isbn>1565921615</bibtex:isbn>
+      <bibtex:url>http://shop.oreilly.com/product/9781565921610.do</bibtex:url>
+    </bibtex:book>
+  </bibtex:entry>
+
+  <bibtex:entry bibtex:id="Adobe1992">
+    <bibtex:book>
+      <bibtex:author>Adobe Developer Technologies</bibtex:author>
+      <bibtex:title>PostScript Language Document Structuring Conventions Specification</bibtex:title>
+      <bibtex:publisher>Adobe Systems Incorporated</bibtex:publisher>
+      <bibtex:year>1992</bibtex:year>
+      <bibtex:size>532522 octets</bibtex:size>
+      <bibtex:url>https://www-cdf.fnal.gov/offline/PostScript/5001.PDF</bibtex:url>
+    </bibtex:book>
+  </bibtex:entry>
+
+  <bibtex:entry bibtex:id="Adobe1992a">
+    <bibtex:book>
+      <bibtex:author>Adobe Systems Incorporated</bibtex:author>
+      <bibtex:title>Encapsulated PostScript File Format Specification, Version 3.0</bibtex:title>
+      <bibtex:publisher>Adobe Systems Incorporated</bibtex:publisher>
+      <bibtex:year>1992</bibtex:year>
+      <bibtex:size>130507 octets</bibtex:size>
+      <bibtex:url>https://www-cdf.fnal.gov/offline/PostScript/5002.PDF</bibtex:url>
+    </bibtex:book>
+  </bibtex:entry>
+
   <bibtex:entry id="AiresDeSousa2002">
     <bibtex:article>
       <bibtex:author>Aires-de-Sousa, J. and Hemmer, M.C. and Gasteiger, J.</bibtex:author>

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -514,8 +514,8 @@
   <bibtex:entry bibtex:id="HAN93">
     <bibtex:phdthesis>
       <bibtex:author>Hanser, Th.</bibtex:author>
-      <bibtex:title>Apprentissage automatique de m�thodes de synth�se � partir d'exemples</bibtex:title>
-      <bibtex:school>Universit� Louis Pasteur</bibtex:school>
+      <bibtex:title>Apprentissage automatique de méthodes de synthèse à partir d'exemples</bibtex:title>
+      <bibtex:school>Université Louis Pasteur</bibtex:school>
       <bibtex:year>1993</bibtex:year>
       <bibtex:address>Strasbourg</bibtex:address>
     </bibtex:phdthesis>

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -98,7 +98,7 @@
       <bibtex:year>2008</bibtex:year>
       <bibtex:volume>80</bibtex:volume>
       <bibtex:number>2</bibtex:number>
-      <bibtex:pages>277–410</bibtex:pages>
+      <bibtex:pages>277--410</bibtex:pages>
     </bibtex:article>
   </bibtex:entry>
   
@@ -969,7 +969,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       <bibtex:journal>J. Chem. Inf. Model.</bibtex:journal>
       <bibtex:year>2009</bibtex:year>
       <bibtex:volume>49</bibtex:volume>
-      <bibtex:pages>338–347</bibtex:pages>
+      <bibtex:pages>338--347</bibtex:pages>
       <bibtex:crossref>DOI:10.1021/ci800326z</bibtex:crossref>
     </bibtex:article>
   </bibtex:entry>

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -232,11 +232,11 @@
     <bibtex:inproceedings>
       <bibtex:author>Borgelt, C. and Berthold, M.R.</bibtex:author>
       <bibtex:title>Mining Molecular Fragments: Finding Relevant Substructures of Molecules</bibtex:title>
-      <bibtex:year>2002</bibtex:year>
       <bibtex:booktitle>ICDM '02: Proceedings of the 2002 IEEE International Conference on Data Mining (ICDM'02)</bibtex:booktitle>
-      <bibtex:isbn>0769517544</bibtex:isbn>
-      <bibtex:publisher>IEEE Computer Society</bibtex:publisher>
+      <bibtex:year>2002</bibtex:year>
       <bibtex:address>Washington, DC, USA</bibtex:address>
+      <bibtex:publisher>IEEE Computer Society</bibtex:publisher>
+      <bibtex:isbn>0769517544</bibtex:isbn>
     </bibtex:inproceedings>
   </bibtex:entry>
 
@@ -397,13 +397,15 @@
   <bibtex:entry bibtex:id="GM2003">
     <bibtex:inbook>
       <bibtex:author>Gasteiger, J.</bibtex:author>
+      <!-- <bibtex:editor>Gasteiger, J.</bibtex:editor> The 'editor'
+           element is alternative to 'author' and they may not be used
+           both -->
       <bibtex:title>A Hierarchy of Structure Representations</bibtex:title>
       <bibtex:chapter>3</bibtex:chapter>
       <bibtex:pages>3219-3288</bibtex:pages>
       <bibtex:year>1980</bibtex:year>
       <bibtex:volume>3</bibtex:volume>
       <bibtex:series>Handbook of Chemoinformatics</bibtex:series>
-      <bibtex:editor>Gasteiger, J.</bibtex:editor>
     </bibtex:inbook>
   </bibtex:entry>
 
@@ -434,9 +436,11 @@
     <bibtex:phdthesis>
       <bibtex:author>Saller, H.</bibtex:author>
       <bibtex:title>Quantitative Emperische Modelle fur Elektronische Effekte in Pi-Systemen und fur die Chemische Reaktivitat</bibtex:title>
-      <bibtex:journal> Tetrahedron</bibtex:journal>
+      <!-- <bibtex:journal>Tetrahedron</bibtex:journal> Journal makes
+           no sense for PhD, does it? It is also forbidden by the
+           schema, for a good reason... -->
+      <bibtex:school>Thecn. Univ. Munchen</bibtex:school>
       <bibtex:year>1985</bibtex:year>
-      <bibtex:adress>Thecn. Univ. Munchen</bibtex:adress>
     </bibtex:phdthesis>
   </bibtex:entry>
   
@@ -536,29 +540,31 @@
       <bibtex:journal>Journal of Cheminformatics</bibtex:journal>
       <bibtex:year>2011</bibtex:year>
       <bibtex:volume>3</bibtex:volume>
-      <bibtex:pages>1-14</bibtex:pages>
       <bibtex:number>1</bibtex:number>
-      <bibtex:url>https://doi.org/10.1186/1758-2946-3-3</bibtex:url>
+      <bibtex:pages>1-14</bibtex:pages>
       <bibtex:crossref>DOI:10.1186/1758-2946-3-3</bibtex:crossref>
+      <bibtex:url>https://doi.org/10.1186/1758-2946-3-3</bibtex:url>
     </bibtex:article>
   </bibtex:entry>
 
 
   <bibtex:entry bibtex:id="HEL99">
     <bibtex:inbook>
-      <bibtex:author>Helson, Harold E.</bibtex:author>
+      <bibtex:editor>Lipkowitz, K. B. and Boyd, D. B.</bibtex:editor>
+      <!-- FIXME: <bibtex:author>Helson, Harold E.</bibtex:author> –
+           here the schema is indeed to restrictive, we need both the
+           editor of the book and the author of the book chapter. -->
       <bibtex:title>Structure Diagram Generation</bibtex:title>
       <bibtex:pages>313-398</bibtex:pages>
       <bibtex:publisher>Wiley-VCH</bibtex:publisher>
       <bibtex:year>1999</bibtex:year>
       <bibtex:volume>13</bibtex:volume>
       <bibtex:series>Reviews in Computational Chemistry</bibtex:series>
-      <bibtex:editor>Lipkowitz, K. B. and Boyd, D. B.</bibtex:editor>
       <bibtex:address>New York</bibtex:address>
     </bibtex:inbook>
   </bibtex:entry>
   
-  <bibtex:entry bibtex:id="BGdV04a">
+  <bibtex:entry bibtex:id="BGDV04a">
     <bibtex:article>
       <bibtex:author>Berger, F. and Gritzmann, P. and De Vries, S.</bibtex:author>
       <bibtex:title>Minimum cycle bases for network graphs</bibtex:title>
@@ -669,16 +675,15 @@
       </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry bibtex:id="kind2007">
+  <bibtex:entry bibtex:id="Kind2007">
       <bibtex:article>
           <bibtex:author>Kind, Tobias   and Fiehn, Oliver</bibtex:author>
-          <bibtex:crossref>DOI:10.1186/1471-2105-8-105</bibtex:crossref>
-          <bibtex:journal>BMC Bioinformatics</bibtex:journal>
-          <bibtex:year>2007</bibtex:year>
           <bibtex:title>Seven Golden Rules for heuristic filtering of molecular formulas
 obtained by accurate mass spectrometry</bibtex:title>
-          <bibtex:volume>8</bibtex:volume>
+          <bibtex:journal>BMC Bioinformatics</bibtex:journal>
           <bibtex:year>2007</bibtex:year>
+          <bibtex:volume>8</bibtex:volume>
+          <bibtex:crossref>DOI:10.1186/1471-2105-8-105</bibtex:crossref>
       </bibtex:article>
   </bibtex:entry>
 
@@ -708,8 +713,8 @@ obtained by accurate mass spectrometry</bibtex:title>
 
   <bibtex:entry bibtex:id="Kreher98">
       <bibtex:book>
-          <bibtex:title>Combinatorial Algorithms Generation Enumeration and Search</bibtex:title>
           <bibtex:author>Kreher, Donald and Stinson, Douglas</bibtex:author>
+          <bibtex:title>Combinatorial Algorithms Generation Enumeration and Search</bibtex:title>
           <bibtex:publisher>CRC Press</bibtex:publisher>
           <bibtex:year>1998</bibtex:year>
       </bibtex:book>
@@ -717,10 +722,10 @@ obtained by accurate mass spectrometry</bibtex:title>
   
   <bibtex:entry bibtex:id="Pluskal2012">
     <bibtex:article>
-      <bibtex:title>Highly accurate chemical formula prediction tool utilizing high-resolution mass spectra, MS/MS fragmentation, heuristic rules, and isotope pattern matching</bibtex:title>
       <bibtex:author>Pluskal, Tomas and Uehara, Taisuke and Yanagida, Mitsuhiro</bibtex:author>
-      <bibtex:year>2012</bibtex:year>
+      <bibtex:title>Highly accurate chemical formula prediction tool utilizing high-resolution mass spectra, MS/MS fragmentation, heuristic rules, and isotope pattern matching</bibtex:title>
       <bibtex:journal>Analytical Chemistry</bibtex:journal>
+      <bibtex:year>2012</bibtex:year>
       <bibtex:volume>84</bibtex:volume>
       <bibtex:number>10</bibtex:number>
       <bibtex:pages>4396-4403</bibtex:pages>
@@ -918,6 +923,7 @@ obtained by accurate mass spectrometry</bibtex:title>
       <bibtex:volume>41</bibtex:volume>
       <bibtex:number>6</bibtex:number>
       <bibtex:pages>1500-1507</bibtex:pages>
+      <bibtex:crossref>DOI:10.1021/ci000407n</bibtex:crossref>
       <bibtex:abstract>The program package SENECA for Computer-Assisted Structure
           Elucidation (CASE) of organic molecules is described.SENECA is written
           completely in the programming language Java and divided into a server, a client,
@@ -931,7 +937,6 @@ obtained by accurate mass spectrometry</bibtex:title>
           heterogeneous network of almost any number and type of computers, thus allowing
           for parallel CASE computations on ordinary networks, present in almost any
           institution.[References: 23]</bibtex:abstract>
-      <bibtex:crossref>DOI:10.1021/ci000407n</bibtex:crossref>
       <bibtex:keywords>Chemical-structure,Natural-products,Spectroscopy,Molecules,Search.,
           Chemistry in Current Contents(R)/Physical, Chemical and Earth,Sciences.</bibtex:keywords>
     </bibtex:article>
@@ -1009,14 +1014,16 @@ obtained by accurate mass spectrometry</bibtex:title>
 
   <bibtex:entry bibtex:id="TOD2000">
     <bibtex:inbook>
-      <bibtex:author>Todeschini, R. and Consonni, V.</bibtex:author>
-      <bibtex:title></bibtex:title>
-      <bibtex:journal>Persepectives in Drug Discovery and Design</bibtex:journal>
-      <bibtex:year>2000</bibtex:year>
       <bibtex:editor>Mannhold, R. and Kubinyi, H. and Timmermann, H.</bibtex:editor>
-      <bibtex:series>Methods and Principles in Medicinal Chemistry</bibtex:series>
-      <bibtex:volume>11</bibtex:volume>
+      <!-- FIXME: <bibtex:author>Todeschini, R. and Consonni,
+           V.</bibtex:author> – schema too restrictive, we need both
+           editor and author -->
+      <bibtex:title>Persepectives in Drug Discovery and Design</bibtex:title>
+      <bibtex:chapter></bibtex:chapter>
       <bibtex:publisher>Wiley-VCH</bibtex:publisher>
+      <bibtex:year>2000</bibtex:year>
+      <bibtex:volume>11</bibtex:volume>
+      <bibtex:series>Methods and Principles in Medicinal Chemistry</bibtex:series>
       <bibtex:address>Weinheim</bibtex:address>
     </bibtex:inbook>
   </bibtex:entry>
@@ -1341,16 +1348,16 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
 
-	<bibtex:entry bibtex:id="SallerH1995">
-    <bibtex:inbook>
-      <bibtex:author>Saller, H.</bibtex:author>
-      <bibtex:title></bibtex:title>
-      <bibtex:pages></bibtex:pages>
-      <bibtex:year>1985</bibtex:year>
-      <bibtex:publisher>TU München</bibtex:publisher>
-      <bibtex:address>München</bibtex:address>
-    </bibtex:inbook>
-  </bibtex:entry>
+    <bibtex:entry bibtex:id="SallerH1995">
+      <bibtex:inbook>
+        <bibtex:author>Saller, H.</bibtex:author>
+        <bibtex:title></bibtex:title>
+        <bibtex:pages></bibtex:pages>
+        <bibtex:publisher>TU München</bibtex:publisher>
+        <bibtex:year>1985</bibtex:year>
+        <bibtex:address>München</bibtex:address>
+      </bibtex:inbook>
+    </bibtex:entry>
 
     <bibtex:entry bibtex:id="HALL1995">
         <bibtex:article>
@@ -1444,13 +1451,13 @@ Method </bibtex:title>
     </bibtex:entry>
 
     <bibtex:entry bibtex:id="WEGNER2006">
-        <bibtex:thesis>
+        <bibtex:phdthesis>
             <bibtex:author>Wegner, J. K.</bibtex:author>
             <bibtex:title>Data Mining und Graph Mining auf molekularen Graphen - Cheminformatik und molekulare Kodierungen f\"{u}r ADME/Tox QSAR Analysen</bibtex:title>
+            <bibtex:school>University of T{\"u}bingen</bibtex:school>
             <bibtex:year>2006</bibtex:year>
             <bibtex:isbn>3832513795</bibtex:isbn>
-            <bibtex:school>University of T{\"u}bingen</bibtex:school>
-        </bibtex:thesis>
+        </bibtex:phdthesis>
     </bibtex:entry>
 
   <bibtex:entry bibtex:id="WILLIGHAGEN2004">
@@ -1505,30 +1512,33 @@ Method </bibtex:title>
   </bibtex:entry>
 
   <bibtex:entry bibtex:id="Klekota01112008">
-  	<bibtex:article>
+    <bibtex:article>
       <bibtex:author>Klekota, Justin and Roth, Frederick P.</bibtex:author>
       <bibtex:title>Chemical substructures that enrich for biological activity</bibtex:title>
-      <bibtex:volume>24</bibtex:volume> 
-      <bibtex:number>21</bibtex:number> 
-      <bibtex:pages>2518-2525</bibtex:pages> 
-      <bibtex:year>2008</bibtex:year> 
-      <bibtex:crossref>DOI:10.1093/bioinformatics/btn479</bibtex:crossref>
-      <bibtex:URL>http://bioinformatics.oxfordjournals.org/content/24/21/2518.abstract</bibtex:URL> 
-      <bibtex:eprint>http://bioinformatics.oxfordjournals.org/content/24/21/2518.full.pdf+html</bibtex:eprint> 
       <bibtex:journal>Bioinformatics</bibtex:journal>
-  	</bibtex:article>
+      <bibtex:year>2008</bibtex:year> 
+      <bibtex:volume>24</bibtex:volume>
+      <bibtex:number>21</bibtex:number>
+      <bibtex:pages>2518-2525</bibtex:pages>
+      <!-- FIXME:
+           <bibtex:eprint>http://bioinformatics.oxfordjournals.org/content/24/21/2518.full.pdf+html</bibtex:eprint>
+           – 'eprint' is not listed as an allowed element in the
+           schema :( -->
+      <bibtex:crossref>DOI:10.1093/bioinformatics/btn479</bibtex:crossref>
+      <bibtex:url>http://bioinformatics.oxfordjournals.org/content/24/21/2518.abstract</bibtex:url> 
+    </bibtex:article>
   </bibtex:entry>
 
     <bibtex:entry bibtex:id="Ullmann76">
         <bibtex:article>
             <bibtex:author>Ullmann J R</bibtex:author>
             <bibtex:title>An Algorithm for Subgraph Isomorphism</bibtex:title>
-            <bibtex:year>1976</bibtex:year>
-            <bibtex:url>http://www.engr.uconn.edu/~vkk06001/GraphIsomorphism/Papers/Ullman_Algorithm.pdf</bibtex:url>
             <bibtex:journal>Journal of the Association for Computing Machinery</bibtex:journal>
+            <bibtex:year>1976</bibtex:year>
             <bibtex:volume>23</bibtex:volume>
             <bibtex:number>1</bibtex:number>
             <bibtex:crossref>DOI:10.1145/321921.321925</bibtex:crossref>
+            <bibtex:url>http://www.engr.uconn.edu/~vkk06001/GraphIsomorphism/Papers/Ullman_Algorithm.pdf</bibtex:url>
         </bibtex:article>
     </bibtex:entry>  
     
@@ -1536,22 +1546,22 @@ Method </bibtex:title>
     <bibtex:article>
       <bibtex:author>Vismara, Philippe</bibtex:author>
       <bibtex:title>Union of all the minimum cycle bases of a graph</bibtex:title>
-      <bibtex:year>1997</bibtex:year>
-      <bibtex:url>http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.47.3674</bibtex:url>
       <bibtex:journal>Combinatorics</bibtex:journal>
+      <bibtex:year>1997</bibtex:year>
       <bibtex:volume>4</bibtex:volume>
       <bibtex:number>1</bibtex:number>
+      <bibtex:url>http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.47.3674</bibtex:url>
     </bibtex:article>
   </bibtex:entry>
 
     <bibtex:entry bibtex:id="InChITechManual">
         <bibtex:manual>
-            <bibtex:title>IUPAC International Chemical Identifier (InChI), InChI
-                version 1, software version 1.04 (2011), Technical Manual
-            </bibtex:title>
             <bibtex:author>Stein, Stephen and Heller, Stephen and Tchekhovskoi,
                 Dmitrii and Pletnev, Igor
             </bibtex:author>
+            <bibtex:title>IUPAC International Chemical Identifier (InChI), InChI
+                version 1, software version 1.04 (2011), Technical Manual
+            </bibtex:title>
             <bibtex:year>2011</bibtex:year>
             <bibtex:url>
                 http://www.inchi-trust.org/fileadmin/user_upload/software/inchi-v1.04/InChI_TechMan.pdf
@@ -1561,10 +1571,10 @@ Method </bibtex:title>
 
     <bibtex:entry bibtex:id="Razinger93">
         <bibtex:article>
-            <bibtex:title>Stereoisomer Generation in Computer-Enhanced Structure Elucidation</bibtex:title>
             <bibtex:author>Razinger, Marko and Balasubramaniam, Krishnan and Perdih, Marko and Munk, Morton</bibtex:author>
-            <bibtex:year>1993</bibtex:year>
+            <bibtex:title>Stereoisomer Generation in Computer-Enhanced Structure Elucidation</bibtex:title>
             <bibtex:journal>J. Chem. Inf. Comput. Sci</bibtex:journal>
+            <bibtex:year>1993</bibtex:year>
             <bibtex:volume>33</bibtex:volume>
             <bibtex:pages>812-825</bibtex:pages>
             <bibtex:crossref>DOI:10.1021/ci00016a003</bibtex:crossref>
@@ -1585,10 +1595,10 @@ Method </bibtex:title>
     
     <bibtex:entry bibtex:id="OBoyle12">
         <bibtex:article>
-            <bibtex:title>Towards a Universal SMILES representation - A standard method to generate canonical SMILES based on the InChI</bibtex:title>
             <bibtex:author>O'Boyle, Noel</bibtex:author>
-            <bibtex:year>2012</bibtex:year>
+            <bibtex:title>Towards a Universal SMILES representation - A standard method to generate canonical SMILES based on the InChI</bibtex:title>
             <bibtex:journal>Journal of Cheminformatics</bibtex:journal>
+            <bibtex:year>2012</bibtex:year>
             <bibtex:volume>4</bibtex:volume>
             <bibtex:number>22</bibtex:number>
             <bibtex:crossref>DOI:10.1186/1758-2946-4-22</bibtex:crossref>
@@ -1597,10 +1607,10 @@ Method </bibtex:title>
     
     <bibtex:entry bibtex:id="Edmonds65">
         <bibtex:article>
-            <bibtex:title>Paths, trees and flowers</bibtex:title>
             <bibtex:author>Edmonds, Jack</bibtex:author>
-            <bibtex:year>1965</bibtex:year>
+            <bibtex:title>Paths, trees and flowers</bibtex:title>
             <bibtex:journal>Canad. J. Math.</bibtex:journal>
+            <bibtex:year>1965</bibtex:year>
             <bibtex:volume>17</bibtex:volume>
             <bibtex:number>449-467</bibtex:number>
         </bibtex:article>
@@ -1608,10 +1618,10 @@ Method </bibtex:title>
     
      <bibtex:entry bibtex:id="Pluskal2012">
         <bibtex:article>
-            <bibtex:title>Highly accurate chemical formula prediction tool utilizing high-resolution mass spectra, MS/MS fragmentation, heuristic rules, and isotope pattern matching</bibtex:title>
             <bibtex:author>Pluskal, Tomas and Uehara, Taisuke and Yanagida, Mitsuhiro</bibtex:author>
-            <bibtex:year>2012</bibtex:year>
+            <bibtex:title>Highly accurate chemical formula prediction tool utilizing high-resolution mass spectra, MS/MS fragmentation, heuristic rules, and isotope pattern matching</bibtex:title>
             <bibtex:journal>Analytical Chemistry</bibtex:journal>
+            <bibtex:year>2012</bibtex:year>
             <bibtex:volume>84</bibtex:volume>
             <bibtex:number>10</bibtex:number>
             <bibtex:pages>4396-4403</bibtex:pages>
@@ -1620,10 +1630,10 @@ Method </bibtex:title>
 
     <bibtex:entry bibtex:id="Boecker2008">
         <bibtex:article>
-            <bibtex:title>DECOMP--from interpreting Mass Spectrometry peaks to solving the Money Changing Problem.</bibtex:title>
             <bibtex:author>Böcker, Sebastian and Lipták, Zsuzsanna and Martin, Marcel and Pervukhin, Anton and Sudek, Henner</bibtex:author>
-            <bibtex:year>2008</bibtex:year>
+            <bibtex:title>DECOMP--from interpreting Mass Spectrometry peaks to solving the Money Changing Problem.</bibtex:title>
             <bibtex:journal>Bioinformatics</bibtex:journal>
+            <bibtex:year>2008</bibtex:year>
             <bibtex:volume>24</bibtex:volume>
             <bibtex:number>4</bibtex:number>
             <bibtex:pages>591--593</bibtex:pages>
@@ -1634,8 +1644,8 @@ Method </bibtex:title>
         <bibtex:inproceedings>
             <bibtex:author>Dührkop, Kai and Ludwig, Marcus and Meusel, Marvin and Böcker, Sebastian</bibtex:author>
             <bibtex:title>Faster mass decomposition</bibtex:title>
-            <bibtex:year>2013</bibtex:year>
             <bibtex:booktitle>Proc. of Workshop on Algorithms in Bioinformatics (WABI 2013)</bibtex:booktitle>
+            <bibtex:year>2013</bibtex:year>
             <bibtex:url>http://arxiv.org/abs/1307.7805</bibtex:url>
         </bibtex:inproceedings>
     </bibtex:entry>

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -564,7 +564,7 @@
     </bibtex:inbook>
   </bibtex:entry>
   
-  <bibtex:entry bibtex:id="BGDV04a">
+  <bibtex:entry bibtex:id="BGdV04c">
     <bibtex:article>
       <bibtex:author>Berger, F. and Gritzmann, P. and De Vries, S.</bibtex:author>
       <bibtex:title>Minimum cycle bases for network graphs</bibtex:title>

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -1616,18 +1616,6 @@ Method </bibtex:title>
         </bibtex:article>
     </bibtex:entry>
     
-     <bibtex:entry bibtex:id="Pluskal2012">
-        <bibtex:article>
-            <bibtex:author>Pluskal, Tomas and Uehara, Taisuke and Yanagida, Mitsuhiro</bibtex:author>
-            <bibtex:title>Highly accurate chemical formula prediction tool utilizing high-resolution mass spectra, MS/MS fragmentation, heuristic rules, and isotope pattern matching</bibtex:title>
-            <bibtex:journal>Analytical Chemistry</bibtex:journal>
-            <bibtex:year>2012</bibtex:year>
-            <bibtex:volume>84</bibtex:volume>
-            <bibtex:number>10</bibtex:number>
-            <bibtex:pages>4396-4403</bibtex:pages>
-        </bibtex:article>
-    </bibtex:entry>
-
     <bibtex:entry bibtex:id="Boecker2008">
         <bibtex:article>
             <bibtex:author>Böcker, Sebastian and Lipták, Zsuzsanna and Martin, Marcel and Pervukhin, Anton and Sudek, Henner</bibtex:author>

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
+<?xml version="1.0" encoding="utf-8"?>
 <bibtex:file xmlns:bibtex="http://bibtexml.sf.net/"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
   xsi:schemaLocation="http://bibtexml.sf.net/ bibtexml.xsd">

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -86,7 +86,7 @@
       <bibtex:title>Blue Obelisk Data Repository (version 10)</bibtex:title>
       <bibtex:howpublished>Figshare</bibtex:howpublished>
       <bibtex:year>2014</bibtex:year>
-      <bibtex:doi>10.6084/m9.figshare.1025775.v1</bibtex:doi>
+      <bibtex:crossref>DOI:10.6084/m9.figshare.1025775.v1</bibtex:crossref>
     </bibtex:misc>
   </bibtex:entry>
 

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -1612,7 +1612,7 @@ Method </bibtex:title>
             <bibtex:journal>Canad. J. Math.</bibtex:journal>
             <bibtex:year>1965</bibtex:year>
             <bibtex:volume>17</bibtex:volume>
-            <bibtex:number>449-467</bibtex:number>
+            <bibtex:pages>449-467</bibtex:pages>
         </bibtex:article>
     </bibtex:entry>
     

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -84,7 +84,7 @@
     <bibtex:misc>
       <bibtex:author>Willighagen, E. and Hutchinson, G. and Niehaus, C. and Buchwald, J. and Pfeiffer, M. and Leidert, D. and Brefort, J.</bibtex:author>
       <bibtex:title>Blue Obelisk Data Repository (version 10)</bibtex:title>
-      <bibtex:journal>Figshare</bibtex:journal>
+      <bibtex:howpublished>Figshare</bibtex:howpublished>
       <bibtex:year>2014</bibtex:year>
       <bibtex:doi>10.6084/m9.figshare.1025775.v1</bibtex:doi>
     </bibtex:misc>

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -564,17 +564,6 @@
     </bibtex:inbook>
   </bibtex:entry>
   
-  <bibtex:entry bibtex:id="BGdV04c">
-    <bibtex:article>
-      <bibtex:author>Berger, F. and Gritzmann, P. and De Vries, S.</bibtex:author>
-      <bibtex:title>Minimum cycle bases for network graphs</bibtex:title>
-      <bibtex:journal>Algorithmica</bibtex:journal>
-      <bibtex:year>2004</bibtex:year>
-      <bibtex:number>1</bibtex:number>
-      <bibtex:pages>51-62</bibtex:pages>
-    </bibtex:article>
-  </bibtex:entry>
-
   <bibtex:entry bibtex:id="HEL01">
     <bibtex:article>
       <bibtex:author>Stein, S. and Heller, S.</bibtex:author>

--- a/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
+++ b/src/main/resources/net/sf/cdk/tools/doclets/cheminf.bibx
@@ -675,7 +675,7 @@
       </bibtex:article>
   </bibtex:entry>
 
-  <bibtex:entry bibtex:id="Kind2007">
+  <bibtex:entry bibtex:id="kind2007">
       <bibtex:article>
           <bibtex:author>Kind, Tobias   and Fiehn, Oliver</bibtex:author>
           <bibtex:title>Seven Golden Rules for heuristic filtering of molecular formulas


### PR DESCRIPTION
The current cheminf.bibx does not validate against the declared http://bibtexml.sf.net/ bibtexml.xsd. It would be useful to have this file validating, so that one might check new additions for validity. The suggested fixes, from the most obvious and and trivial to the more problematic ones are listed below.
Simple suggested changes:
- encoding is 'utf-8', not 'iso-8859-1' as declared;
- n-dashes ('–') should be replaced by one or two hyphens ('--') according to the schema;
- the 'id' attribute in 'entry' elements should have explicit namespace, since the schema specified 'attributeFormDefault=qualified';
- order of elements should be fixed;
- identical duplicate entry 'Pluskal2012' should be removed;
- fix encoding of French characters in 'HAN93';
- in the 'Edmonds65' entry, 449-467 seem to be 'pages', not 'number' (?).
More problematic fixes:
- the schema does not specify the <bibtex:doi> element; a suggested workaround would be to used <bibtex:crossref>DOI:10..../....</bibtex:crossref>, with no loss of information and possibility to transfor automatically once <bibtex:doi> or similar element is in place;
- the schema does not allow both editor and author to be specified for 'inbook' entries; I do not see any good way to represent this except enhancing the schema;
- the schema does not contain 'eprint' element to specified the desired in-print URIs; I do not see any good way to represent this except enhancing the schema;
- some required values (page numbers, volume numbers) are missing.

One could also use 'xmlns="http://bibtexml.sf.net/"' and drop the "bibtex:" prefixs from element names, that would make file smaller and remove a lot of duplication noise...